### PR TITLE
To PR or not to PR

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Ian Huet
 Principal Engineer specialised in web based UI development. Customer focused, product centric, quality based.
 
-Profile: [https://www.linkedin.com/in/ian-huet-bbb2aa4/](https://www.linkedin.com/in/ian-huet-bbb2aa4/)
+**Profile:** [https://www.linkedin.com/in/ian-huet-bbb2aa4/](https://www.linkedin.com/in/ian-huet-bbb2aa4/)
 
 ### Development Journal
 Exploring ideas, reflecting on encounters, investigating alternatives, clarifying thoughts, looking for ways to get the best of things.
@@ -9,4 +9,6 @@ Exploring ideas, reflecting on encounters, investigating alternatives, clarifyin
 ## Posts
 
 ### 2023
+[To PR or Not to PR](https://journal.huet.info/to_pr_or_not_to_pr) - what is a more meaningful question
+
 [The Mystery 8%](https://journal.huet.info/mystery_8_percent) - code coverage vs. test coverage

--- a/mystery_8_percent.md
+++ b/mystery_8_percent.md
@@ -7,10 +7,8 @@ excerpt: "Beware the gap between code & test coverage"
 # The Mystery 8%
 Beware the gap between code & test coverage
 
-## TL;DR
-A [test coverage threshold](https://jestjs.io/docs/configuration#coveragethreshold-object) can be a useful tool to drive improved test coverage. Yet it is only part of the process, it is important to be vigilant for large increases as code coverage reports are calculated on the amount of code executed, not on the amount of code tested.
-
-Sudden jumps in code coverage are an indicator of poor practice. Unchecked this is counter productive.
+### TLDR
+> A [test coverage threshold](https://jestjs.io/docs/configuration#coveragethreshold-object) can be a useful tool to drive improved test coverage. Yet it is only part of the process, it is important to be vigilant for large increases as code coverage reports are calculated on the amount of code executed, not on the amount of code tested. Sudden jumps in code coverage are an indicator of poor practice. Unchecked this is counter productive.
 
 ---
 

--- a/to_pr_or_not_to_pr.md
+++ b/to_pr_or_not_to_pr.md
@@ -1,43 +1,39 @@
 ---
 title: "To PR or not to PR"
 date: "2023-05-26"
-excerpt: "Is that the most meaningful question"
+excerpt: "Is that the most meaningful question?"
 ---
 
 # To PR or not to PR
-Is that the most meaningful question
+Is that the most meaningful question?
 
-## TL;DR
-
-Debate around the use of the "Pull Request" process is endless. For all the arguments against it I remain an advocate for using PRs. Reflecting on this position brought me to the [Ship / Show / Ask](https://martinfowler.com/articles/ship-show-ask.html) adaptation of the PR approach. It offers an easily communicated middle-ground between CI & PRs. Yet, coming to this middle-ground served me to highlight how many factors outside the branching strategy debate this topic encompasses.
+#### TL;DR
+> Debate on the Pull Request (PR) process is endless. Yet for all the arguments against it I'm for PRs. Reflecting on this position brought me to the [Ship / Show / Ask](https://martinfowler.com/articles/ship-show-ask.html) adaptation of the process. It offers an easily communicated middle-ground between traditional PRs & mainline CI. Yet, coming to this middle-ground highlighted how branching strategy debate is more about human practice than technical guard rails.
 
 ---
 
-For many years PRs have been the only process I've worked with for team development work. A recent internal project initially followed that same trend. This served us well in terms of sharing knowledge as the project rapidly evolved. However, the development of the projects core functionality fell to an engineer who drove a 'merge now & figure out the issues later' approach.
+For many years PRs have been the only process I've worked with for team development work. A recent internal project initially followed that same trend. This served us well in terms of sharing knowledge as the project rapidly evolved. However, the development of the projects core functionality fell to an engineer who drove a merge to mainline approach instead.
 
-I found this challenging for a variety of reasons. Not least because it flew in the face of what I'd come to consider the 'right' way. In response I looked for a counter argument.
+I found this challenging for a variety of reasons. Not least because it flew in the face of what I had become so accustomed to being the 'right' way. I urgently looked for a counter argument. During that process I realised several things:
 
-and only later realising the dogmatic place I was coming from 
+- I was dogmatic in my initial response.
+- For every arguement [against PRs](https://blog.arkency.com/disadvantages-of-pull-requests/), there is an equally valid counter arguement [for PRs](https://productive.io/engineering/blog/pull-requests-the-good-the-bad-and-really-not-that-ugly/).
+- Looking again at possible [branching strategies](https://martinfowler.com/articles/branching-patterns.html) led me to [Rouan Wilsenach's Ship/Shop/Ask](https://martinfowler.com/articles/ship-show-ask.html)
 
+As a declared PR advocate this offers a more nuanced approach than I'd previously held. It requires no new technology to implement, repository merge configuration tweaks only ([GitHub](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges), [GitLab](https://docs.gitlab.com/ee/user/project/merge_requests/approvals/settings.html), [BitBucket](https://support.atlassian.com/bitbucket-cloud/docs/pull-request-and-merge-settings/), etc.). It's easy to communicate. It also retains the routine checks & balances of PRs. This with the option for more rapid throughput among experienced, trusted engineers.
 
-* habit challenged by claut
-* reflect on process options, consider release tooling
-* ship / show / ask
-  - well honed review practice
-  - disipline / responsibility mindset
-  - documentation / knowledge sharing
-  - team work / better PR practice
-  - monitor via source control metrics
+Yet, regardless of the branching strategy well honed collaboration practice is fundamental to successful progress. In my opinion the most important aspects of that practice include small merge diffs, automated code linting, professional reviews (prompt, respectful, thorough, and practical), and monitoring via source control metrics. Further to this varied forms of communication (advance planning, retrospective, product focused, technically oriented, formal, informal, etc.) are good for team health, encouraged or scheduled without straining delivery commitments of course.
 
 ## Take aways
 
-- Avoid holding onto dogmatic positions
-- The best answer is specific to each team/organisation
-- Periodically revisit any decision
-- Align on balance between throughput & DevEx
-
+- Only firmly hold a position when no other options are available, and that position can be wholistically supported.
+- Align on balance between throughput, output quality & DevEx.
+- The 'right' process is specific to each team or organisation and best served by being open to evolution.
 
 ### References:
+
+Pull Request vs. Merge Request: Definition, Differences, and More
+- https://www.simplilearn.com/pull-vs-merge-request-definition-differences-benefits-article#what_is_a_merge_request
 
 Disadvantages of Pull Requests
 - https://blog.arkency.com/disadvantages-of-pull-requests/

--- a/to_pr_or_not_to_pr.md
+++ b/to_pr_or_not_to_pr.md
@@ -1,0 +1,55 @@
+---
+title: "To PR or not to PR"
+date: "2023-05-26"
+excerpt: "Is that the most meaningful question"
+---
+
+# To PR or not to PR
+Is that the most meaningful question
+
+## TL;DR
+
+Debate around the use of the "Pull Request" process is endless. For all the arguments against it I remain an advocate for using PRs. Reflecting on this position brought me to the [Ship / Show / Ask](https://martinfowler.com/articles/ship-show-ask.html) adaptation of the PR approach. It offers an easily communicated middle-ground between CI & PRs. Yet, coming to this middle-ground served me to highlight how many factors outside the branching strategy debate this topic encompasses.
+
+---
+
+For many years PRs have been the only process I've worked with for team development work. A recent internal project initially followed that same trend. This served us well in terms of sharing knowledge as the project rapidly evolved. However, the development of the projects core functionality fell to an engineer who drove a 'merge now & figure out the issues later' approach.
+
+I found this challenging for a variety of reasons. Not least because it flew in the face of what I'd come to consider the 'right' way. In response I looked for a counter argument.
+
+and only later realising the dogmatic place I was coming from 
+
+
+* habit challenged by claut
+* reflect on process options, consider release tooling
+* ship / show / ask
+  - well honed review practice
+  - disipline / responsibility mindset
+  - documentation / knowledge sharing
+  - team work / better PR practice
+  - monitor via source control metrics
+
+## Take aways
+
+- Avoid holding onto dogmatic positions
+- The best answer is specific to each team/organisation
+- Periodically revisit any decision
+- Align on balance between throughput & DevEx
+
+
+### References:
+
+Disadvantages of Pull Requests
+- https://blog.arkency.com/disadvantages-of-pull-requests/
+
+Pull Requests — The Good, the Bad and Really, Not That Ugly
+- https://productive.io/engineering/blog/pull-requests-the-good-the-bad-and-really-not-that-ugly/
+
+Why code reviews matter (and actually save time!)
+- https://www.atlassian.com/agile/software-development/code-reviews
+
+Patterns for Managing Source Code Branches
+- https://martinfowler.com/articles/branching-patterns.html
+
+Ship-Show-Ask
+- https://martinfowler.com/articles/ship-show-ask.html


### PR DESCRIPTION
Debate on the Pull Request (PR) process is endless. Yet for all the arguments against it I'm for PRs. Reflecting on this position brought me to the Ship / Show / Ask adaptation of the process. It offers an easily communicated middle-ground between traditional PRs & mainline CI. Yet, coming to this middle-ground highlighted how branching strategy debate is more about human practice than technical guard rails.